### PR TITLE
Fix force-unwrapped URL assumption

### DIFF
--- a/IPAPI/IPAPI.swift
+++ b/IPAPI/IPAPI.swift
@@ -19,7 +19,10 @@ open class IPAPI {
   fileprivate static let endpointUrl = "http://ip-api.com/json"
   
   open class func location(_ session: URLSession) -> Observable<IPGeoData?> {
-    let url = URL(string: endpointUrl)!
+    guard let url: URL = URL(string: endpointUrl) else {
+        return Observable<IPGeoData?>.just(nil)
+    }
+
     return session.rx
       .json(url: url)
       .observeOn(MainScheduler.asyncInstance)


### PR DESCRIPTION
Force-unwrapping the URL should be fine, but if for some reason it is
not, this will crash any app using the framework. This change allows
for graceful degradation, in such a case.